### PR TITLE
Opening up ELK port and changing docker installation method

### DIFF
--- a/Standing_Up_Tools/doa_stack.json
+++ b/Standing_Up_Tools/doa_stack.json
@@ -133,21 +133,12 @@
                         "Fn::Join": [
                             "", [
                                 "#!/bin/bash\n",
-                                "cat > /etc/yum.repos.d/docker.repo <<-'EOF'\n",
-                                "[dockerrepo]\n",
-                                "name=Docker Repository\n",
-                                "baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/\n",
-                                "enabled=1\n",
-                                "gpgcheck=1\n",
-                                "gpgkey=https://yum.dockerproject.org/gpg\n",
-                                "EOF\n",
-                                "echo '\n==============================================================================='\n",
+                                "yum update -y\n",
+								"curl -fsSL https://get.docker.com/ | sed 's/docker-engine/docker-engine-1.10.3-1.el7.centos/' | sh\n",
+								"echo '\n==============================================================================='\n",
                                 "echo '=========================== Installing Yum Packages ==========================='\n",
                                 "echo '===============================================================================\n'\n",
-                                "yum -y install wget\n",
-                                "yum -y install unzip\n",
-                                "yum -y install git\n",
-                                "yum -y install docker-engine-1.10.3-1.el7.centos.x86_64\n",
+                                "yum -y install wget unzip git\n",
                                 "grep 'tcp://0.0.0.0:2375' /usr/lib/systemd/system/docker.service || sed -i 's#ExecStart\\(.*\\)$#ExecStart\\1 -H tcp://0.0.0.0:2375#' /usr/lib/systemd/system/docker.service\n",
                                 "systemctl daemon-reload && systemctl restart docker\n",
                                 "echo '\n==============================================================================='\n",
@@ -241,7 +232,7 @@
                     "IpProtocol": "tcp",
                     "ToPort": "443"
                 }, {
-                    "CidrIp": "10.0.0.0/16",
+                    "CidrIp": "0.0.0.0/0",
                     "FromPort": "25826",
                     "IpProtocol": "udp",
                     "ToPort": "25826"


### PR DESCRIPTION
- Index creation on Kibana was failing due to port being accessible only via the VPC
- Using the curleable shell script to install docker as opposed to using a yum repo