### PR TITLE
Enabled dockerd to bind to /var/run/docker.sock when started via systemd

### DIFF
--- a/Standing_Up_Tools/doa_stack.json
+++ b/Standing_Up_Tools/doa_stack.json
@@ -142,7 +142,7 @@
                                 "echo '=========================== Installing Yum Packages ==========================='\n",
                                 "echo '===============================================================================\n'\n",
                                 "yum -y install wget unzip git\n",
-                                "grep 'tcp://0.0.0.0:2375' /usr/lib/systemd/system/docker.service || sed -i 's#ExecStart\\(.*\\)$#ExecStart\\1 -H tcp://0.0.0.0:2375#' /usr/lib/systemd/system/docker.service\n",
+                                "grep 'tcp://0.0.0.0:2375' /usr/lib/systemd/system/docker.service || sed -i 's#ExecStart\\(.*\\)$#ExecStart\\1 -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock#' /usr/lib/systemd/system/docker.service\n",
                                 "systemctl daemon-reload && systemctl restart docker\n",
                                 "systemctl enable docker.service\n",
                                 "echo '\n==============================================================================='\n",


### PR DESCRIPTION
I’ve been running the DOA this week and the chef and docker labs no longer work as a result of the recent changes to run dockerd via systemd.

The doa_stack.json script must be changed so that the /usr/lib/systemd/system/docker.service binds to the docker socket.

