### PR TITLE
Updating Tomcat AMI IDs

### DIFF
--- a/Lab_Modules/Module_7/Tomcat_7.json
+++ b/Lab_Modules/Module_7/Tomcat_7.json
@@ -7,7 +7,7 @@
           "AMI": "ami-049b6e6b"
         },
         "eu-west-1": {
-          "AMI": "ami-00369873"
+          "AMI": "ami-4bdd8332"
         },
         "us-east-1": {
           "AMI": "ami-542eae43"
@@ -19,10 +19,10 @@
           "AMI": "ami-698acc09"
         },
         "ap-southeast-1":{
-          "AMI": "ami-42f25121"
+          "AMI": "ami-141e3b68"
         },
         "ap-southeast-2": {
-          "AMI": "ami-f0406a93"
+          "AMI": "ami-620bc500"
         },
         "ap-south-1": {
           "AMI": "ami-16c8a279"

--- a/Lab_Modules/Module_7/Tomcat_8.json
+++ b/Lab_Modules/Module_7/Tomcat_8.json
@@ -4,28 +4,28 @@
   "Mappings": {
       "RegionMap": {
         "eu-central-1": {
-          "AMI": "ami-9bf712f4"
+          "AMI": "ami-2882ddc3"
         },
         "eu-west-1": {
-          "AMI": "ami-7abd0209"
+          "AMI": "ami-1caef165"
         },
         "us-east-1": {
-          "AMI": "ami-6d1c2007"
+          "AMI": "ami-b81dbfc5"
         },
         "us-west-2": {
-          "AMI": "ami-d2c924b2"
+          "AMI": "ami-0ebdd976"
         },
         "us-west-1": {
-          "AMI": "ami-af4333cf"
+          "AMI": "ami-78485818"
         },
         "ap-southeast-1":{
-          "AMI": "ami-f068a193"
+          "AMI": "ami-16a4fe6a"
         },
         "ap-southeast-2": {
-          "AMI": "ami-fedafc9d"
+          "AMI": "ami-dda36dbf"
         },
         "ap-south-1": {
-          "AMI": "ami-95cda6fa"
+          "AMI": "ami-2014314f"
         }
       }
   }, 


### PR DESCRIPTION
This PR updates the Tomcat AMI IDs, as some of the Tomcat 7 AMIs had been deleted and the Tomcat 8 AMIs have been taken out of circulation.

The Centos 7 AMIs for the Tomcat 8 template come from here: https://aws.amazon.com/marketplace/fulfillment?productId=b7ee8a69-ee97-4a49-9e68-afaee216db2e