### PR TITLE
Lock DOA to set version of adop-docker-compose with platform management versioning

### DIFF
--- a/Standing_Up_Tools/doa_stack.json
+++ b/Standing_Up_Tools/doa_stack.json
@@ -176,7 +176,7 @@
                                 "git clone https://github.com/Accenture/adop-docker-compose\n",
 
                                 "cd /data/adop-docker-compose\n",
-                                "git checkout 394a56ddbd83bcd69af30997f767c2ea7006322d\n",
+                                "git checkout 19b6fa4b50c998dbb98cf03e019d61e14a0a112b\n",
                                 "export METADATA_URL='http://169.254.169.254/latest/meta-data'\n",
                                 "export MAC_ADDRESS=$(curl -s ${METADATA_URL}/network/interfaces/macs/)\n",
                                 "export AWS_VPC_ID=$(curl -s ${METADATA_URL}/network/interfaces/macs/${MAC_ADDRESS}/vpc-id/)\n",


### PR DESCRIPTION
In order to unblock https://github.com/Accenture/adop-platform-management/pull/53 setting adop-docker-compose to a fixed version with platform management versioning.

Please see standing up DOA via AWS Console or CLI in this repository's readme for testing instructions.

Expected behavour: Load Platform checkouts this "53db75040b44fb94a1ce2d300944e33912c62dfa" version of platform management.

Test results

![image](https://user-images.githubusercontent.com/487240/40407986-003d0fbc-5e5e-11e8-9ab1-fbf2b9aba99f.png)
