### PR TITLE
Changing AMI for eu-west-1 region

### DIFF
--- a/Standing_Up_Tools/doa_stack.json
+++ b/Standing_Up_Tools/doa_stack.json
@@ -8,7 +8,7 @@
             "AMI": "ami-337be65c"
           },
           "eu-west-1": {
-            "AMI": "ami-6e28b517"
+            "AMI": "ami-005b5c720e7b986d6"
           },
           "eu-west-2": {
             "AMI": "ami-ee6a718a"


### PR DESCRIPTION
The stack creation was failing for eu-west-1(Ireland) region with below error.

"The following resource(s) failed to create: [DOAWaitCondition]. . Rollback requested by user."
After changing the AMI stack is created successfully.